### PR TITLE
Add setup script for arc

### DIFF
--- a/scripts/ai2_internal/setup_on_arc.sh
+++ b/scripts/ai2_internal/setup_on_arc.sh
@@ -29,5 +29,4 @@ poetry install
 # Install any task specific dependencies, e.g.
 poetry install -E "summarization"
 
-
 cd "$PROJECT/$USER/retrieval-exploration"


### PR DESCRIPTION
This PR adds a script for setting up the package on [ARC](https://alliancecan.ca/en/services/advanced-research-computing). In the future I will add similar setup scripts for other environments (ai2 servers, AWS, etc.).