### PR TITLE
Fix incorrect key "ref_abstracts" everywhere

### DIFF
--- a/scripts/run_summarization.py
+++ b/scripts/run_summarization.py
@@ -555,7 +555,7 @@ def main():
                     text, summary = util.preprocess_multi_x_science_sum(
                         text=examples[text_column][i],
                         summary=examples[summary_column][i],
-                        ref_abstracts=examples["ref_abstracts"][i],
+                        ref_abstract=examples["ref_abstract"][i],
                         doc_sep_token=doc_sep_token,
                     )
                 else:
@@ -801,6 +801,8 @@ def main():
             model_type="microsoft/deberta-large-mnli",
             rescale_with_baseline=True,
             use_fast_tokenizer=True,
+            device="cuda",
+            batch_size=32
         )
         for key, value in bertscore_results.items():
             if key == "hashcode":
@@ -831,6 +833,8 @@ def main():
             results["per_perturbed"] = data_args.per_perturbed
             results["seed"] = training_args.seed
             results["model_name_or_path"] = model_args.model_name_or_path
+            results["doc_sep_token"] = doc_sep_token
+            results["inputs"] = decoded_inputs
             results["labels"] = decoded_labels
             results["preds"] = decoded_preds
 

--- a/src/retrieval_exploration/common/util.py
+++ b/src/retrieval_exploration/common/util.py
@@ -33,10 +33,10 @@ def preprocess_multi_news(text: str, summary: str, doc_sep_token: str) -> Tuple[
 
 
 def preprocess_multi_x_science_sum(
-    text: str, summary: str, ref_abstracts: Dict[str, List[str]], doc_sep_token: str
+    text: str, summary: str, ref_abstract: Dict[str, List[str]], doc_sep_token: str
 ) -> Tuple[str, str]:
     """Given an `example` dict, returns a tuple of strings containing the text and summary."""
-    abstracts = [abstract.strip() for abstract in ref_abstracts["abstract"]]
+    abstracts = [abstract.strip() for abstract in ref_abstract["abstract"]]
     text = f" {doc_sep_token} ".join([text.strip()] + abstracts)
     summary = summary.strip()
     return text, summary

--- a/tests/common/test_util.py
+++ b/tests/common/test_util.py
@@ -46,7 +46,7 @@ def test_preprocess_multi_x_science_sum() -> None:
     doc_sep_token = "<doc-sep>"
 
     abstract = "This is the query abstract."
-    ref_abstracts = {"abstract": ["This is a cited abstract."]}
+    ref_abstract = {"abstract": ["This is a cited abstract."]}
     related_work = "This is the related work."
 
     expected_text, expected_summary = (
@@ -56,7 +56,7 @@ def test_preprocess_multi_x_science_sum() -> None:
     actual_text, actual_summary = util.preprocess_multi_x_science_sum(
         text=abstract,
         summary=related_work,
-        ref_abstracts=ref_abstracts,
+        ref_abstract=ref_abstract,
         doc_sep_token=doc_sep_token,
     )
     assert expected_text == actual_text


### PR DESCRIPTION
I had the incorrect key for `ref_abstracts` (should be `ref_abstract`) everywhere for the multi-x-science-sum dataset. This PR addresses that.