### PR TITLE
Remove modified config from all primera configs

### DIFF
--- a/conf/multi_news/primera/train/addition.json
+++ b/conf/multi_news/primera/train/addition.json
@@ -1,6 +1,5 @@
 {
     "model_name_or_path": "allenai/PRIMERA-multinews",
-    "config_name": "./allenai/PRIMERA-multinews-fix",
     "dataset_name": "multi_news",
     "text_column": "document",
     "summary_column": "summary",

--- a/conf/multi_news/primera/train/baseline.json
+++ b/conf/multi_news/primera/train/baseline.json
@@ -1,6 +1,5 @@
 {
     "model_name_or_path": "allenai/PRIMERA-multinews",
-    "config_name": "./allenai/PRIMERA-multinews-fix",
     "dataset_name": "multi_news",
     "text_column": "document",
     "summary_column": "summary",

--- a/conf/multi_news/primera/train/deletion.json
+++ b/conf/multi_news/primera/train/deletion.json
@@ -1,6 +1,5 @@
 {
     "model_name_or_path": "allenai/PRIMERA-multinews",
-    "config_name": "./allenai/PRIMERA-multinews-fix",
     "dataset_name": "multi_news",
     "text_column": "document",
     "summary_column": "summary",

--- a/conf/multi_news/primera/train/duplication.json
+++ b/conf/multi_news/primera/train/duplication.json
@@ -1,6 +1,5 @@
 {
     "model_name_or_path": "allenai/PRIMERA-multinews",
-    "config_name": "./allenai/PRIMERA-multinews-fix",
     "dataset_name": "multi_news",
     "text_column": "document",
     "summary_column": "summary",

--- a/conf/multixscience/primera/train/addition.json
+++ b/conf/multixscience/primera/train/addition.json
@@ -1,6 +1,5 @@
 {
     "model_name_or_path": "allenai/PRIMERA-multixscience",
-    "config_name": "./allenai/PRIMERA-multixscience-fix",
     "dataset_name": "multi_x_science_sum",
     "text_column": "abstract",
     "summary_column": "related_work",

--- a/conf/multixscience/primera/train/baseline.json
+++ b/conf/multixscience/primera/train/baseline.json
@@ -1,6 +1,5 @@
 {
     "model_name_or_path": "allenai/PRIMERA-multixscience",
-    "config_name": "./allenai/PRIMERA-multixscience-fix",
     "dataset_name": "multi_x_science_sum",
     "text_column": "abstract",
     "summary_column": "related_work",

--- a/conf/multixscience/primera/train/deletion.json
+++ b/conf/multixscience/primera/train/deletion.json
@@ -1,6 +1,5 @@
 {
     "model_name_or_path": "allenai/PRIMERA-multixscience",
-    "config_name": "./allenai/PRIMERA-multixscience-fix",
     "dataset_name": "multi_x_science_sum",
     "text_column": "abstract",
     "summary_column": "related_work",

--- a/conf/multixscience/primera/train/duplication.json
+++ b/conf/multixscience/primera/train/duplication.json
@@ -1,6 +1,5 @@
 {
     "model_name_or_path": "allenai/PRIMERA-multixscience",
-    "config_name": "./allenai/PRIMERA-multixscience-fix",
     "dataset_name": "multi_x_science_sum",
     "text_column": "abstract",
     "summary_column": "related_work",


### PR DESCRIPTION
We used to have a modified PRIMERA config saved locally, but [the fix has now been merged upstream](https://github.com/allenai/PRIMER/issues/9), so this PR removes all references to the local config from our PRIMERA confs.