### PR TITLE
Accept full dataset in call to map

### DIFF
--- a/scripts/run_summarization.py
+++ b/scripts/run_summarization.py
@@ -741,6 +741,7 @@ def main():
                 remove_columns=column_names,
                 load_from_cache_file=not data_args.overwrite_cache,
                 desc="Running tokenizer on train dataset",
+                batch_size=None,
             )
 
     if training_args.do_eval:
@@ -759,6 +760,7 @@ def main():
                 remove_columns=column_names,
                 load_from_cache_file=not data_args.overwrite_cache,
                 desc="Running tokenizer on validation dataset",
+                batch_size=None,
             )
 
     if training_args.do_predict:
@@ -777,6 +779,7 @@ def main():
                 remove_columns=column_names,
                 load_from_cache_file=not data_args.overwrite_cache,
                 desc="Running tokenizer on prediction dataset",
+                batch_size=None,
             )
 
     # Data collator


### PR DESCRIPTION
Accept the full dataset in call to `map`, which gives us the biggest possible population to sample documents from.