### PR TITLE
Remove task specific params once and for all

### DIFF
--- a/scripts/run_summarization.py
+++ b/scripts/run_summarization.py
@@ -445,14 +445,6 @@ def main():
         use_auth_token=True if model_args.use_auth_token else None,
     )
 
-    # Use summarization specific params if present in the config
-    task_specific_params = util.get_task_specific_params(model.config, task="summarization")
-    if task_specific_params is not None:
-        logger.info(
-            "Using summarization specific params from model config (note, some of these may be"
-            " overridden by arguments passed to this script)."
-        )
-
     model.resize_token_embeddings(len(tokenizer))
 
     if model.config.decoder_start_token_id is None and isinstance(tokenizer, (MBartTokenizer, MBartTokenizerFast)):

--- a/src/retrieval_exploration/common/util.py
+++ b/src/retrieval_exploration/common/util.py
@@ -8,7 +8,7 @@ import flatten_dict
 import numpy as np
 import pandas as pd
 from tqdm import tqdm
-from transformers import PretrainedConfig, PreTrainedTokenizer
+from transformers import PreTrainedTokenizer
 
 # Local constants
 _DOC_SEP_TOKENS = {"primera": "<doc-sep>", "multi_news": "|||||"}
@@ -134,15 +134,6 @@ def preprocess_ms2(
     text = f" {doc_sep_token} ".join([background] + articles)
     summary = summary.strip()
     return text, summary
-
-
-def get_task_specific_params(config: PretrainedConfig, task: str) -> Optional[Dict[str, Any]]:
-    task_specific_params = None
-    if config.task_specific_params is not None:
-        task_specific_params = config.task_specific_params.get(task)
-        if task_specific_params:
-            config.update(task_specific_params)
-    return task_specific_params
 
 
 def get_global_attention_mask(input_ids: List[List[int]], token_ids: List[int]) -> List[List[int]]:

--- a/tests/common/test_util.py
+++ b/tests/common/test_util.py
@@ -1,4 +1,3 @@
-import copy
 import warnings
 from typing import Callable, List
 
@@ -131,23 +130,6 @@ def test_preprocess_ms2() -> None:
     )
     assert expected_text == actual_text
     assert expected_summary == actual_summary
-
-
-def test_get_task_specific_params(hf_config: Callable) -> None:
-    # Choose a model we know has task-specific parameters
-    config = hf_config("allenai/PRIMERA")
-    assert config.early_stopping is False
-
-    # Check that we get the expected params and that the underlying model config was updated
-    summarization_specific_params = util.get_task_specific_params(config, task="summarization")
-    assert summarization_specific_params == config.task_specific_params["summarization"]
-    assert config.early_stopping is True
-
-    # Check that model config is not modified if no task-specific params are found
-    config_copy = copy.deepcopy(config)
-    translation_specific_params = util.get_task_specific_params(config, task="translation")
-    assert translation_specific_params is None
-    assert config_copy == config
 
 
 def test_get_doc_sep_token(hf_tokenizer: Callable) -> None:


### PR DESCRIPTION
Remove the logic for pulling task specific params out of a config. In general I think this is a bad idea.