### PR TITLE
Reduce multinews primera batch size

### DIFF
--- a/conf/multinews/primera/eval.yml
+++ b/conf/multinews/primera/eval.yml
@@ -8,4 +8,4 @@ max_target_length: 1024
 
 # Seq2SeqTrainingArguments
 do_predict: true
-per_device_eval_batch_size: 12
+per_device_eval_batch_size: 10


### PR DESCRIPTION
Reduce the default PRIMERA eval batch size on Multi-News. Previous value was sometimes resulting in OOMs.