### PR TITLE
Reduce CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.8, 3.9]
+        os: [ubuntu-latest]
+        python-version: [3.9]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Reduce the number of CI builds by removing windows and macOS from the matrix. Also removes python 3.8.