### PR TITLE
Open cache only when reading or writing

### DIFF
--- a/src/retrieval_exploration/perturbations.py
+++ b/src/retrieval_exploration/perturbations.py
@@ -581,9 +581,9 @@ class Perturber:
         """
         back_translated_docs = []
 
-        with Cache(util.CACHE_DIR) as reference:
-            for doc in documents:
-                key = f"{_BT_FROM_MODEL_NAME}_{_BT_TO_MODEL_NAME}_{util.sanitize_text(doc, lowercase=True)}"
+        for doc in documents:
+            key = f"{_BT_FROM_MODEL_NAME}_{_BT_TO_MODEL_NAME}_{util.sanitize_text(doc, lowercase=True)}"
+            with Cache(util.CACHE_DIR) as reference:
                 if key in reference:
                     back_translated_docs.append(reference[key])
                 else:


### PR DESCRIPTION
This PR just tweaks the caching mechanism for back-translation so that the cache is only open when reading and writing, and then immediately closed again. This leads to less issues when multiple jobs running in parallel are trying to access the cache.