### PR TITLE
Fix build issue due to torch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,9 @@ diskcache = "^5.4.0"
 platformdirs = "^2.5.2"
 typer = "^0.6.1"
 rich = "^12.5.1"
-# Skip torch=1.13.0, as there are issues installing with poetry (see https://github.com/pytorch/pytorch/issues/88049)
-torch = "^1.10.0,!=1.13.0"
+# Skip torch=1.13.0, as there are issues installing with poetry.
+# See https://github.com/pytorch/pytorch/issues/88049 and https://github.com/python-poetry/poetry/issues/6939
+torch = "^1.13.1"
 transformers = "^4.19.0"
 tokenizers = "^0.12.1"
 datasets = "^2.4.0"


### PR DESCRIPTION
Poetry would not export a `requirements.txt` file (which is neccecary to install on ARC clusters) because of bad metadata in the `torch` PyPI index. This problem is solved by bumping the minimum version of `torch` to `1.13.1`.

### Other changes

- Improve the install instructions on ARC clusters